### PR TITLE
Solved stack underflow issue caused by characters separated by multiple spaces.

### DIFF
--- a/autoexec.cfg
+++ b/autoexec.cfg
@@ -19,7 +19,7 @@ alias dnload_text "GetColoredText"
 alias spk_all "commandmode msg"
 // Replacing this long function parameter with a single parameter ${1-}.
 // ${1-} means all the parameters provided to the alias.
-alias msg "set send_var \"${1-}\"; srt_msg"
+alias msg "set send_var \"${1- ?}\"; srt_msg" // get all the entries or empty if nothing provided
 alias srt_msg "format send_var; defer 0.5 print_chat"
 // set a button we can use to chat with
 bind o "spk_all"
@@ -50,7 +50,7 @@ echo "^7[^2*^7] ^3Setting up essential functions...^7"
 set if_condition ""
 alias noop ""
 
-alias if_else_cmp "rpn /if_condition ${1} ${3} ${2} =; alias if_action1 ${4}; alias if_action0 ${5 ?}; if_execute"
+alias if_else_cmp "rpn /if_condition /${1 ?} /${3 ?} ${2} =; alias if_action1 ${4}; alias if_action0 ${5 ?}; if_execute"
 alias if_execute "if_action${if_condition}"
 alias if_action0 "noop"
 
@@ -110,7 +110,7 @@ echo "^1TEST:^2 If function test...^7"
 echo "^1>> ^2if 305 == 305 \"echo YEP\" \"echo NOPE\" -> YEP^7"
 if_else_cmp 305 == 305 "echo YEP" "echo NOPE" // integer test
 
-echo "^2if_else_cmp string == 305 \"echo YEP\" \"echo NOPE\" -> NOPE^7"
+echo "^1>> ^2if_else_cmp string == 305 \"echo YEP\" \"echo NOPE\" -> NOPE^7"
 if_else_cmp string == 305 "echo YEP" "echo NOPE" // string & string test
 
 // array function
@@ -122,13 +122,17 @@ array.index 3 test_array; echo ${array_result}
 // format text function
 echo "^1TEST:^2 format text function...^7"
 set test_array "Hello, this is a test message!"
-echo "^1>> ^2format test_array -> Hello,+this+is+a+test+message!+^7"
+echo "^1>> ^2format test_array"
 format test_array; echo $formated
+
+set special_chars " ! @ # $ % ^ & * ( ) - + [  ] {  } : | < > ? ` ~ ' " // supported chars, these can be separated by space or a part of words.
+echo "^1>> ^2special_chars = ${special_chars} ; format special_chars^7"
+format special_chars; echo $formated
 
 echo "^1----------------------END------------------------^7"
 
 echo "^7[^2*^7]: ^3Client side chat server configuration completed.^7"
 
-//============================================================//
-// 													END
-//============================================================//
+//==============================//
+//	END
+//==============================//


### PR DESCRIPTION
Hey, so the issue has been fixed.
1) deal with empty inputs to the `msg` command, so `$1-` itself isn't passed as a request parameter when no paramater is provided to `msg` cmd.
```diff
-alias msg "set send_var \"${1-}\"; srt_msg"
+alias msg "set send_var \"${1- ?}\"; srt_msg" // get all the entries or empty if nothing provided
```
2) `if_else_cmp` can now deal with strings ( format function should work fine with characters separated by multiple spaces ), fixing `stack underflow` issue.
```
Nick: [MSG]: but  f  f  f  f  f  over  no
rpn: stack underflow
rpn: empty cvar name for 'def'
DONE FORMATING 
```
 it can work with all of these characters `- + ! @ # $ % ^ & * ( ) _ { } [ ] , . ' < > |` separated by space or in combination with words, only limitation is these characters ` \ / ; "`.
 ```diff
-alias if_else_cmp "rpn /if_condition ${1} ${3} ${2} =; alias if_action1 ${4}; alias if_action0 ${5 ?}; if_execute"
+alias if_else_cmp "rpn /if_condition /${1 ?} /${3 ?} ${2} =; alias if_action1 ${4}; alias if_action0 ${5 ?}; if_execute"
```
Note: Currently `format` function cannot convert literal `+` sign in the input string to valid url equivalent.

Have a great day!